### PR TITLE
Write to temp file first and then rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 *.iml
 *.json
 /build
+
+bin/
+.classpath
+.project
+.settings/

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ targetCompatibility = 1.7
 
 
 group = 'ch.papers'
-version = '1.1.2'
+version = '1.1.3'
 
 repositories {
     mavenLocal()


### PR DESCRIPTION
Changes: 
- write to temporary file first and then rename the temp file to the final file. Should prevent writing only half of the file (e.g. when app quits).
- increased version
